### PR TITLE
🔨 Trigger Run Lint on Save if Tox is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.12
+
+- Trigger *Run Lint on Save* if Tox is available (either via virtual environment or as a globally installed package).
+
 ## 0.0.11
 
 - Avoid parallel triggering of *Run Lint on Save*.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-juju-charmcraft-ide",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-juju-charmcraft-ide",
-            "version": "0.0.11",
+            "version": "0.0.12",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.8.5",
                 "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-juju-charmcraft-ide",
     "displayName": "Charmcraft IDE",
     "description": "VS Code extension for Juju Charm development",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "publisher": "babakks",
     "repository": {
         "type": "git",

--- a/src/venv.ts
+++ b/src/venv.ts
@@ -13,6 +13,35 @@ export type ExecutionEnv = {
     [key: string]: string | undefined;
 };
 
+export interface ExecOptions {
+    /**
+     * Command to execute.
+     */
+
+    command: string;
+
+    /**
+     * Arguments to pass to the command.
+     */
+    args?: string[];
+
+    /**
+     * Working directory to run the command in. Default is charm's home directory.
+     */
+    cwd?: vscode.Uri;
+
+    /**
+     * Environment variables to populate when running the command.
+     */
+    env?: ExecutionEnv;
+
+    /**
+     * Disables activation of virtual environment, if any, prior to executing
+     * the command.
+     */
+    notActivate?: boolean;
+}
+
 /**
  * Environment variables which are set/reset when activating/deactivating a
  * virtual env.
@@ -96,11 +125,16 @@ export class VirtualEnv implements vscode.Disposable {
     }
 
     /**
-     * Executes given command within the virtual environment, in the charm home
-     * directory.
+     * Executes given command.
      */
-    async exec(command: string, args?: string[], cwd?: vscode.Uri, env?: ExecutionEnv): Promise<ExecutionResult> {
-        return await this._exec(cwd?.fsPath ?? this.charmHome.path, command, args, env);
+    async exec(options: ExecOptions): Promise<ExecutionResult> {
+        return await this._exec(
+            options.cwd?.fsPath ?? this.charmHome.path,
+            options.command,
+            options.args,
+            options.env,
+            options.notActivate,
+        );
     }
 
     /**

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -441,10 +441,6 @@ export class WorkspaceCharm implements vscode.Disposable {
                 : Object.values(this.model.toxConfig.sections).find(v => v.env === s)
         ).filter((s): s is CharmToxConfigSection => !!s);
 
-        if (!correspondingToxSections.length) {
-            return new Map();
-        }
-
         const executions = [
             ...correspondingToxSections.map(x =>
                 this.backgroundWorkerManager.execute(x.name, () =>

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -466,8 +466,8 @@ export class WorkspaceCharm implements vscode.Disposable {
             ...correspondingToxSections.map(x =>
                 this.backgroundWorkerManager.execute(x.name, () =>
                     this.virtualEnv.exec({
-                        command: 'tox',
-                        args: ['-e', x.env, '-x', `${x.name}.ignore_errors=True`],
+                        command: 'python3',
+                        args: ['-m', 'tox', '-e', x.env, '-x', `${x.name}.ignore_errors=True`],
                         notActivate: !this.hasVirtualEnv, // To activate the virtual env, if there's one.
                     }))),
             ...commands.map(x => this.virtualEnv.execInShell(x)),

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -473,6 +473,10 @@ export class WorkspaceCharm implements vscode.Disposable {
             ...commands.map(x => this.virtualEnv.execInShell(x)),
         ];
 
+        if (!executions.length) {
+            return new Map();
+        }
+
         const t0 = new Date();
         const results = await Promise.allSettled(executions);
         const duration = new Date().getTime() - t0.getTime();

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -428,6 +428,15 @@ export class WorkspaceCharm implements vscode.Disposable {
         this._onLintOnSave.fire();
     }
 
+    private async _checkToxAvailable(): Promise<boolean> {
+        const result = await this.virtualEnv.exec({
+            command: 'python3',
+            args: ['-c', 'import tox'],
+            notActivate: !this.hasVirtualEnv, // To activate the virtual env, if there's one.
+        });
+        return result.code === 0;
+    }
+
     private async _getSourceCodeLinterDiagnostics(): Promise<Map<string, vscode.Diagnostic[]>> {
         const commands = this.hasVirtualEnv && this.config?.runLintOnSave?.commands || [];
         const toxSections = this.config?.runLintOnSave?.tox ?? [CHARM_TOX_LINT_SECTION];

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -446,6 +446,22 @@ export class WorkspaceCharm implements vscode.Disposable {
                 : Object.values(this.model.toxConfig.sections).find(v => v.env === s)
         ).filter((s): s is CharmToxConfigSection => !!s);
 
+        if (correspondingToxSections.length && !(await this._checkToxAvailable())) {
+            if (this.hasVirtualEnv) {
+                vscode.window.showErrorMessage(
+                    "There is a virtual environment but Tox is not installed in it. " +
+                    "Please install Tox in the virtual environment or try setting up the virtual environment again. " +
+                    `(Charm at ${this.home.path})`
+                );
+            } else {
+                vscode.window.showErrorMessage(
+                    "Tox is not installed. Please either install it globally or setup a virtual environment. "+
+                    `(Charm at ${this.home.path})`
+                );
+            }
+            correspondingToxSections.splice(0);
+        }
+
         const executions = [
             ...correspondingToxSections.map(x =>
                 this.backgroundWorkerManager.execute(x.name, () =>


### PR DESCRIPTION
This PR allows *Run Lint on Save* to take place whenever Tox is available; either via a virtual environment or as a globally installed package. Before this PR, having a virtual environment was required.
