### PR TITLE
🎁 Allow custom launch configuration fields when debugging tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.14
+
+- Allow for custom launch configuration fields when debugging tests.
+
 ## 0.0.13
 
 - Show individual configuration parameters and actions in the sidebar tree.

--- a/README.md
+++ b/README.md
@@ -47,21 +47,34 @@ Currently, diagnostics are interpreted for these linters:
 
 ℹ️ To disable the *Run Lint on Save* option, set `charmcraft-ide.runLintOnSave` configuration's `enabled` parameter to `false`.
 
+## Debugging external libraries
+
+To be able to step into external library code when debugging tests, you can use custom launch configuration fields to set the `justMyCode` to `false`. To do this, add the line below to your `.vscode/settings.json` file:
+
+```json
+{
+    "charmcraft-ide.test.customDebugLaunchConfig": {
+        "justMyCode": false
+    }
+}
+```
+
 ## Configuration
 
 These are some configuration parameters that you can set in `.vscode/settings.json` file of your workspace:
 
-| Parameter                                   | Type       | Default            | Description                                                                                          |
-| ------------------------------------------- | ---------- | ------------------ | ---------------------------------------------------------------------------------------------------- |
-| `charmcraft-ide.ignore`                     | `string`   | (empty)            | Relative path Glob pattern of charm directories to ignore.                                           |
-| `charmcraft-ide.defaultVirtualEnvDirectory` | `string`   | `"venv"`           | Name of directory to setup/detect Python virtual environments.                                       |
-| `charmcraft-ide.runLintOnSave`              | `object`   | `{}`               | Options to configure *Run Lint on Save* feature.                                                     |
-| `charmcraft-ide.runLintOnSave.enabled`      | `boolean`  | `true`             | Enables/disables *Run Lint on Save* feature.                                                         |
-| `charmcraft-ide.runLintOnSave.tox`          | `string[]` | `["testenv:lint"]` | Linting-related Tox environment(s)/section(s) to run.                                                |
-| `charmcraft-ide.runLintOnSave.commands`     | `string[]` | `[]`               | Linting-related commands to run.                                                                     |
-| `charmcraft-ide.runLintOnSave.exclude`      | `string[]` | `[]`               | Array of linters to exclude their diagnostics; for example, `["flake8"]`.                            |
-| `charmcraft-ide.runLintOnSave.include`      | `string[]` | `[]`               | Array of linters to include their diagnostics and exclude other linters'; for example, `["flake8"]`. |
-| `charmcraft-ide.override`                   | `object`   | `{}`               | Charm-specific overrides (See [Charm-specific overrides](#charm-specific-overrides)).                |
+| Parameter                                     | Type       | Default            | Description                                                                                                   |
+| --------------------------------------------- | ---------- | ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `charmcraft-ide.ignore`                       | `string`   | (empty)            | Relative path Glob pattern of charm directories to ignore.                                                    |
+| `charmcraft-ide.defaultVirtualEnvDirectory`   | `string`   | `"venv"`           | Name of directory to setup/detect Python virtual environments.                                                |
+| `charmcraft-ide.test.customDebugLaunchConfig` | `object`   | `{}`               | Custom fields to include in launch configuration when debugging tests; for example `{ "justMyCode": false }`. |
+| `charmcraft-ide.runLintOnSave`                | `object`   | `{}`               | Options to configure *Run Lint on Save* feature.                                                              |
+| `charmcraft-ide.runLintOnSave.enabled`        | `boolean`  | `true`             | Enables/disables *Run Lint on Save* feature.                                                                  |
+| `charmcraft-ide.runLintOnSave.tox`            | `string[]` | `["testenv:lint"]` | Linting-related Tox environment(s)/section(s) to run.                                                         |
+| `charmcraft-ide.runLintOnSave.commands`       | `string[]` | `[]`               | Linting-related commands to run.                                                                              |
+| `charmcraft-ide.runLintOnSave.exclude`        | `string[]` | `[]`               | Array of linters to exclude their diagnostics; for example, `["flake8"]`.                                     |
+| `charmcraft-ide.runLintOnSave.include`        | `string[]` | `[]`               | Array of linters to include their diagnostics and exclude other linters'; for example, `["flake8"]`.          |
+| `charmcraft-ide.override`                     | `object`   | `{}`               | Charm-specific overrides (See [Charm-specific overrides](#charm-specific-overrides)).                         |
 
 ## Charm-specific overrides
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-juju-charmcraft-ide",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-juju-charmcraft-ide",
-            "version": "0.0.13",
+            "version": "0.0.14",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.8.5",
                 "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-juju-charmcraft-ide",
     "displayName": "Charmcraft IDE",
     "description": "VS Code extension for Juju Charm development",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "publisher": "babakks",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,10 @@
                     "type": "string",
                     "markdownDescription": "Default directory name to setup/detect virtual environments (default is `venv`). This value affects all charms in a workspace, so if you need to change it for some specific charm, use the `override` parameter."
                 },
+                "charmcraft-ide.test.customDebugLaunchConfig": {
+                    "type": "object",
+                    "markdownDescription": "Custom fields to include in launch configuration; for example, setting `justMyCode` to `false` to debug external libraries."
+                },
                 "charmcraft-ide.runLintOnSave": {
                     "type": "object",
                     "properties": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { Disposable, EventEmitter, WorkspaceConfiguration, workspace } from 'vscode';
+import { Disposable, EventEmitter, workspace } from 'vscode';
 
 /**
  * Workspace/global-scoped configuration parameters.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { Disposable, EventEmitter, workspace } from 'vscode';
+import { Disposable, EventEmitter, workspace, type WorkspaceConfiguration } from 'vscode';
 
 /**
  * Workspace/global-scoped configuration parameters.
@@ -17,6 +17,11 @@ export interface WorkspaceConfig {
     runLintOnSave?: WorkspaceRunLintOnSaveConfig;
 
     /**
+     * Configurations specific to charm testing features.
+     */
+    test: WorkspaceTestConfig;
+
+    /**
      * Charm-specific overrides. Keys are relative paths of charm directories or
      * their parent directories.
      * 
@@ -25,6 +30,16 @@ export interface WorkspaceConfig {
     override?: {
         [key: string]: WorkspaceOverrideConfig;
     };
+}
+
+/**
+ * Configurations related to charm testing features.
+ */
+export interface WorkspaceTestConfig {
+    /**
+     * Custom fields to include in launch configuration when debugging tests.
+     */
+    customDebugLaunchConfig?: { [key: string]: any }
 }
 
 export interface WorkspaceRunLintOnSaveConfig {
@@ -66,6 +81,9 @@ const CONFIG_KEY_OVERRIDE = 'override';
 const CONFIG_KEY_OVERRIDE_VENV_DIR = 'virtualEnvDirectory';
 const CONFIG_KEY_OVERRIDE_RUN_LINT_ON_SAVE = 'runLintOnSave';
 
+const CONFIG_SECTION_TEST = 'charmcraft-ide.test';
+const CONFIG_KEY_TEST_DEBUG_CUSTOM_LAUNCH_CONFIG = 'customDebugLaunchConfig';
+
 const CONFIG_SUBKEY_RUN_LINT_ON_SAVE_ENABLED = 'enabled';
 const CONFIG_SUBKEY_RUN_LINT_ON_SAVE_TOX = 'tox';
 const CONFIG_SUBKEY_RUN_LINT_ON_SAVE_COMMANDS = 'commands';
@@ -106,8 +124,11 @@ export class ConfigManager implements Disposable {
      */
     getLatest(): WorkspaceConfig {
         const config = workspace.getConfiguration(CONFIG_SECTION);
+        const testConfig = workspace.getConfiguration(CONFIG_SECTION_TEST);
 
-        const result: WorkspaceConfig = {};
+        const result: WorkspaceConfig = {
+            test: {},
+        };
 
         /*
          * Note that here to avoid putting default values in more than one
@@ -131,6 +152,14 @@ export class ConfigManager implements Disposable {
         const runLintOnSave = parseRunLintOnSave(readParameterIgnoreDefault(CONFIG_KEY_RUN_LINT_ON_SAVE));
         if (runLintOnSave !== undefined) {
             result.runLintOnSave = runLintOnSave;
+        }
+
+        const customDebugLaunchConfig = optionalStringMap(readParameterIgnoreDefault(
+            CONFIG_KEY_TEST_DEBUG_CUSTOM_LAUNCH_CONFIG,
+            testConfig,
+        ));
+        if (customDebugLaunchConfig !== undefined) {
+            result.test.customDebugLaunchConfig = customDebugLaunchConfig;
         }
 
         const override = loadOverride(readParameterIgnoreDefault(CONFIG_KEY_OVERRIDE));
@@ -227,8 +256,12 @@ export class ConfigManager implements Disposable {
             return typeof v === 'object' && Array.isArray(v) ? v : undefined;
         }
 
-        function readParameterIgnoreDefault(key: string): any {
-            const i = config.inspect(key);
+        function optionalStringMap(v: any): { [key: string]: any } | undefined {
+            return typeof v === 'object' && !Array.isArray(v) ? v : undefined;
+        }
+
+        function readParameterIgnoreDefault(key: string, c?: WorkspaceConfiguration): any {
+            const i = (c ?? config).inspect(key);
             return i?.workspaceValue ?? i?.globalValue;
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ export async function activate(context: ExtensionContext) {
         ...registerCompletionProviders(registry, reporter),
         ...registerHoverProviders(registry, reporter),
         ...registerDefinitionProviders(registry, reporter),
-        ...registerTestProvider(registry, ic, reporter, output, testOutput, context.logUri),
+        ...registerTestProvider(configManager, registry, ic, reporter, output, testOutput, context.logUri),
     );
 
     // Note that we shouldn't `await` on this call, because it could ask for user decision (e.g., to install the YAML
@@ -143,8 +143,8 @@ function registerDefinitionProviders(registry: Registry, reporter: TelemetryRepo
     ];
 }
 
-function registerTestProvider(registry: Registry, ic: InternalCommands, reporter: TelemetryReporter, output: OutputChannel, testOutput: OutputChannel, logUri: Uri): Disposable[] {
+function registerTestProvider(configManager: ConfigManager, registry: Registry, ic: InternalCommands, reporter: TelemetryReporter, output: OutputChannel, testOutput: OutputChannel, logUri: Uri): Disposable[] {
     const controller = tests.createTestController('charmcraft-ide', 'Charmcraft IDE');
-    const provider = new CharmTestProvider(registry, ic, reporter, controller, output, testOutput, logUri);
+    const provider = new CharmTestProvider(configManager, registry, ic, reporter, controller, output, testOutput, logUri);
     return [controller, provider];
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -794,7 +794,7 @@ export function parseCharmMetadataYAML(text: string): CharmMetadata {
     }
 }
 
-const _TOX_SECTION_PATTERN = /(?<parent>.*):(?<env>[^:]+)$/
+const _TOX_SECTION_PATTERN = /(?<parent>.*):(?<env>[^:]+)$/;
 export function parseToxINI(text: string): CharmToxConfig {
     let parsed = {};
     try {

--- a/src/test.ts
+++ b/src/test.ts
@@ -618,6 +618,8 @@ export class CharmTestProvider implements Disposable {
             return;
         }
 
+        const customDebugLaunchConfig = this.configManager.getLatest().test.customDebugLaunchConfig ?? {};
+
         const pythonBinaryPath = await workspaceCharm.virtualEnv.getPythonExecutablePath();
 
         const { pytestArgs, cwd } = this._getPytestCommand(data, workspaceCharm.home, relativePath);
@@ -659,6 +661,7 @@ export class CharmTestProvider implements Disposable {
                 env,
                 args: pytestArgs,
                 console: "internalConsole",
+                ...customDebugLaunchConfig,
             },
         );
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -31,6 +31,7 @@ import { spawn } from 'child_process';
 import { randomUUID } from 'crypto';
 import { COMMAND_CREATE_AND_SETUP_VIRTUAL_ENVIRONMENT } from './command.const';
 import { InternalCommands } from './command';
+import type { ConfigManager } from './config';
 
 type TestData = CharmTestData | DirectoryTestData | FileTestData | FunctionTestData | ClassTestData | MethodTestData;
 
@@ -92,6 +93,7 @@ export class CharmTestProvider implements Disposable {
     readonly onUpdate = this._onUpdate.event;
 
     constructor(
+        readonly configManager: ConfigManager,
         readonly registry: Registry,
         readonly ic: InternalCommands,
         readonly reporter: TelemetryReporter,

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,6 @@
 import TelemetryReporter from '@vscode/extension-telemetry';
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
 import {
     CancellationToken,
     DebugAdapterTracker,
@@ -21,17 +23,15 @@ import {
     window,
     workspace
 } from 'vscode';
+import { InternalCommands } from './command';
+import { COMMAND_CREATE_AND_SETUP_VIRTUAL_ENVIRONMENT } from './command.const';
+import type { ConfigManager } from './config';
+import { CHARM_DIR_TESTS } from './model/common';
 import { Registry } from './registry';
 import { rangeToVSCodeRange, tryReadWorkspaceFileAsText } from './util';
+import { WorkspaceCharm } from './workspace';
 import assert = require('assert');
 import path = require('path');
-import { WorkspaceCharm } from './workspace';
-import { CHARM_DIR_TESTS } from './model/common';
-import { spawn } from 'child_process';
-import { randomUUID } from 'crypto';
-import { COMMAND_CREATE_AND_SETUP_VIRTUAL_ENVIRONMENT } from './command.const';
-import { InternalCommands } from './command';
-import type { ConfigManager } from './config';
 
 type TestData = CharmTestData | DirectoryTestData | FileTestData | FunctionTestData | ClassTestData | MethodTestData;
 


### PR DESCRIPTION
This PR adds a new configuration parameter, named `charmcraft-ide.test.customDebugLaunchConfig` (defaults to `{}`).

Fixes #28