### PR TITLE
Fix source code analyzer issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.18
+
+- Fix bug in analyzing source/test files.
+
 ## 0.0.17
 
 - Fix duplicate charms in the sidebar tree.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-juju-charmcraft-ide",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-juju-charmcraft-ide",
-            "version": "0.0.17",
+            "version": "0.0.18",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.8.5",
                 "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-juju-charmcraft-ide",
     "displayName": "Charmcraft IDE",
     "description": "VS Code extension for Juju Charm development",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "publisher": "babakks",
     "repository": {
         "type": "git",

--- a/src/parser/common.ts
+++ b/src/parser/common.ts
@@ -482,7 +482,7 @@ export async function getPythonAST(content: string): Promise<any | undefined> {
     const tmp = await mkdtemp(path.join(tmpdir(), 'juju-charms-ide'));
     try {
         const tmpfile = path.join(tmp, 'temp.py');
-        const scriptPath = path.join(__dirname, '../resource/ast/python-ast-to-json.py');
+        const scriptPath = path.join(__dirname, '../../resource/ast/python-ast-to-json.py');
         await writeFile(tmpfile, content);
 
         const [exitCode, ast] = await new Promise<[number, string]>(function (resolve, reject) {


### PR DESCRIPTION
Due to some changes to the source code directory structure, the relative path to the Python AST parser script was invalid. This PR fixes that.

Fixes #38 