### PR TITLE
Add cross-file diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.0.19
+
+- Fix bug in parsing maps in YAML files.
+- Add cross-file diagnostics for `charmcraft.yaml`, `actions.yaml`, and `config.yaml`.
+
 ## 0.0.18
 
 - Fix bug in analyzing source/test files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-juju-charmcraft-ide",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-juju-charmcraft-ide",
-            "version": "0.0.18",
+            "version": "0.0.19",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.8.5",
                 "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-juju-charmcraft-ide",
     "displayName": "Charmcraft IDE",
     "description": "VS Code extension for Juju Charm development",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "publisher": "babakks",
     "repository": {
         "type": "git",

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -49,8 +49,8 @@ export class CharmConfigDefinitionProvider implements DefinitionProvider {
             return;
         }
 
-        const node = option.definition === 'charmcraft.yaml' ? workspaceCharm.live.charmcraftYAML.config?.value?.options?.entries?.[name]?.node :
-            option.definition === 'config.yaml' ? workspaceCharm.live.configYAML.parameters?.entries?.[name]?.node : undefined;
+        const node = option.definition === 'charmcraft.yaml' ? workspaceCharm.live.charmcraftYAML?.config?.value?.options?.entries?.[name]?.node :
+            option.definition === 'config.yaml' ? workspaceCharm.live.configYAML?.parameters?.entries?.[name]?.node : undefined;
         if (!node?.range) {
             return;
         }
@@ -99,8 +99,8 @@ export class CharmEventDefinitionProvider implements DefinitionProvider {
             return;
         }
 
-        const node = event.definition === 'charmcraft.yaml' ? workspaceCharm.live.charmcraftYAML.actions?.entries?.[event.sourceActionName]?.node :
-            event.definition === 'actions.yaml' ? workspaceCharm.live.actionsYAML.actions?.entries?.[event.sourceActionName]?.node : undefined;
+        const node = event.definition === 'charmcraft.yaml' ? workspaceCharm.live.charmcraftYAML?.actions?.entries?.[event.sourceActionName]?.node :
+            event.definition === 'actions.yaml' ? workspaceCharm.live.actionsYAML?.actions?.entries?.[event.sourceActionName]?.node : undefined;
         if (!node?.range) {
             return;
         }

--- a/src/model/actions.yaml.ts
+++ b/src/model/actions.yaml.ts
@@ -1,4 +1,4 @@
-import { emptyYAMLNode, type MapWithNode, type WithNode, type YAMLNode } from "./yaml";
+import { type MapWithNode, type WithNode, type YAMLNode } from "./yaml";
 
 export interface CharmAction {
     name: string;
@@ -12,10 +12,4 @@ export interface CharmActions {
      * Root node.
      */
     node: YAMLNode;
-}
-
-export function emptyActions(): CharmActions {
-    return {
-        node: emptyYAMLNode(),
-    };
 }

--- a/src/model/charm.ts
+++ b/src/model/charm.ts
@@ -111,11 +111,11 @@ const CHARM_SECRET_EVENTS: CharmEvent[] = [
 ];
 
 export class Charm {
-    private _charmcraftYAML: charmcraftYAML.CharmCharmcraft = charmcraftYAML.emptyCharmcraft();
-    private _configYAML: configYAML.CharmConfig = configYAML.emptyConfig();
-    private _actionsYAML: actionsYAML.CharmActions = actionsYAML.emptyActions();
-    private _metadataYAML: metadataYAML.CharmMetadata = metadataYAML.emptyMetadata();
-    private _toxINI: toxINI.CharmToxConfig = toxINI.emptyToxConfig();
+    private _charmcraftYAML: charmcraftYAML.CharmCharmcraft | undefined;
+    private _configYAML: configYAML.CharmConfig | undefined;
+    private _actionsYAML: actionsYAML.CharmActions | undefined;
+    private _metadataYAML: metadataYAML.CharmMetadata | undefined;
+    private _toxINI: toxINI.CharmToxConfig | undefined;
 
     private _events: CharmEvent[] = [];
     private _eventMap = new Map<string, CharmEvent>();
@@ -135,7 +135,7 @@ export class Charm {
      * Note that the recommended reference for charm configurations is the
      * `charmcraft.yaml` file.
      */
-    get configYAML(): configYAML.CharmConfig {
+    get configYAML(): configYAML.CharmConfig | undefined {
         return this._configYAML;
     }
 
@@ -145,7 +145,7 @@ export class Charm {
      * Note that the recommended reference for charm actions is the
      * `charmcraft.yaml` file.
      */
-    get actionsYAML(): actionsYAML.CharmActions {
+    get actionsYAML(): actionsYAML.CharmActions | undefined {
         return this._actionsYAML;
     }
 
@@ -233,21 +233,21 @@ export class Charm {
      * Note that the recommended reference for charm metadata is the
      * `charmcraft.yaml`.
      */
-    get metadataYAML(): metadataYAML.CharmMetadata {
+    get metadataYAML(): metadataYAML.CharmMetadata | undefined {
         return this._metadataYAML;
     }
 
     /**
      * Represents information stored in the charm's `charmcraft.yaml` file.
      */
-    get charmcraftYAML(): charmcraftYAML.CharmCharmcraft {
+    get charmcraftYAML(): charmcraftYAML.CharmCharmcraft | undefined {
         return this._charmcraftYAML;
     }
 
     /**
      * Represents information stored in the charm's `tox.ini` file.
      */
-    get toxINI(): toxINI.CharmToxConfig {
+    get toxINI(): toxINI.CharmToxConfig | undefined {
         return this._toxINI;
     }
 
@@ -255,30 +255,30 @@ export class Charm {
         return this._sourceCode;
     }
 
-    async updateActionsYAML(actions: actionsYAML.CharmActions) {
+    async updateActionsYAML(actions: actionsYAML.CharmActions | undefined) {
         this._actionsYAML = actions;
         this._repopulateEvents();
         this._repopulateActions();
     }
 
-    async updateConfigYAML(config: configYAML.CharmConfig) {
+    async updateConfigYAML(config: configYAML.CharmConfig | undefined) {
         this._configYAML = config;
         this._repopulateConfigOptions();
     }
 
-    async updateMetadataYAML(metadata: metadataYAML.CharmMetadata) {
+    async updateMetadataYAML(metadata: metadataYAML.CharmMetadata | undefined) {
         this._metadataYAML = metadata;
         this._repopulateEvents();
     }
 
-    async updateCharmcraftYAML(charmcraft: charmcraftYAML.CharmCharmcraft) {
+    async updateCharmcraftYAML(charmcraft: charmcraftYAML.CharmCharmcraft | undefined) {
         this._charmcraftYAML = charmcraft;
         this._repopulateEvents();
         this._repopulateActions();
         this._repopulateConfigOptions();
     }
 
-    async updateToxINI(toxINI: toxINI.CharmToxConfig) {
+    async updateToxINI(toxINI: toxINI.CharmToxConfig | undefined) {
         this._toxINI = toxINI;
     }
 
@@ -299,23 +299,23 @@ export class Charm {
             // style. That is why below events are extracted from both
             // `actions.yaml`/`metadata.yaml` and `charmcraft.yaml` information.
 
-            ...Object.entries(this._actionsYAML.actions?.entries ?? {}).filter(([, action]) => action.value).map(([, action]) => renderCharmActionEvents(action.value!, 'actions.yaml')).flat(1),
-            ...Object.entries(this._metadataYAML.storage?.entries ?? {}).filter(([, storage]) => storage.value).map(([, storage]) => renderCharmStorageEvents(storage.value!, 'metadata.yaml')).flat(1),
-            ...Object.entries(this._metadataYAML.containers?.entries ?? {}).filter(([, container]) => container.value).map(([, container]) => renderCharmContainerEvents(container.value!, 'metadata.yaml')).flat(1),
-            ...Object.entries(this._metadataYAML.peers?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/peer', 'metadata.yaml')).flat(1),
-            ...Object.entries(this._metadataYAML.provides?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/provides', 'metadata.yaml')).flat(1),
-            ...Object.entries(this._metadataYAML.requires?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/requires', 'metadata.yaml')).flat(1),
+            ...Object.entries(this._actionsYAML?.actions?.entries ?? {}).filter(([, action]) => action.value).map(([, action]) => renderCharmActionEvents(action.value!, 'actions.yaml')).flat(1),
+            ...Object.entries(this._metadataYAML?.storage?.entries ?? {}).filter(([, storage]) => storage.value).map(([, storage]) => renderCharmStorageEvents(storage.value!, 'metadata.yaml')).flat(1),
+            ...Object.entries(this._metadataYAML?.containers?.entries ?? {}).filter(([, container]) => container.value).map(([, container]) => renderCharmContainerEvents(container.value!, 'metadata.yaml')).flat(1),
+            ...Object.entries(this._metadataYAML?.peers?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/peer', 'metadata.yaml')).flat(1),
+            ...Object.entries(this._metadataYAML?.provides?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/provides', 'metadata.yaml')).flat(1),
+            ...Object.entries(this._metadataYAML?.requires?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/requires', 'metadata.yaml')).flat(1),
 
             // Events related to information in `charmcraft.yaml` are defined
             // after all those related to `metadata.yaml` or `actions.yaml` in
             // order to override duplicate names (see the map creation loop
             // below).
-            ...Object.entries(this._charmcraftYAML.actions?.entries ?? {}).filter(([, action]) => action.value).map(([, action]) => renderCharmActionEvents(action.value!, 'charmcraft.yaml')).flat(1),
-            ...Object.entries(this._charmcraftYAML.storage?.entries ?? {}).filter(([, storage]) => storage.value).map(([, storage]) => renderCharmStorageEvents(storage.value!, 'charmcraft.yaml')).flat(1),
-            ...Object.entries(this._charmcraftYAML.containers?.entries ?? {}).filter(([, container]) => container.value).map(([, container]) => renderCharmContainerEvents(container.value!, 'charmcraft.yaml')).flat(1),
-            ...Object.entries(this._charmcraftYAML.peers?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/peer', 'charmcraft.yaml')).flat(1),
-            ...Object.entries(this._charmcraftYAML.provides?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/provides', 'charmcraft.yaml')).flat(1),
-            ...Object.entries(this._charmcraftYAML.requires?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/requires', 'charmcraft.yaml')).flat(1),
+            ...Object.entries(this._charmcraftYAML?.actions?.entries ?? {}).filter(([, action]) => action.value).map(([, action]) => renderCharmActionEvents(action.value!, 'charmcraft.yaml')).flat(1),
+            ...Object.entries(this._charmcraftYAML?.storage?.entries ?? {}).filter(([, storage]) => storage.value).map(([, storage]) => renderCharmStorageEvents(storage.value!, 'charmcraft.yaml')).flat(1),
+            ...Object.entries(this._charmcraftYAML?.containers?.entries ?? {}).filter(([, container]) => container.value).map(([, container]) => renderCharmContainerEvents(container.value!, 'charmcraft.yaml')).flat(1),
+            ...Object.entries(this._charmcraftYAML?.peers?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/peer', 'charmcraft.yaml')).flat(1),
+            ...Object.entries(this._charmcraftYAML?.provides?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/provides', 'charmcraft.yaml')).flat(1),
+            ...Object.entries(this._charmcraftYAML?.requires?.entries ?? {}).filter(([, endpoint]) => endpoint.value).map(([, endpoint]) => renderCharmRelationEvents(endpoint.value!, 'endpoints/requires', 'charmcraft.yaml')).flat(1),
         ];
 
         this._eventSymbolMap.clear();

--- a/src/model/charmcraft.yaml.ts
+++ b/src/model/charmcraft.yaml.ts
@@ -1,5 +1,5 @@
 import { type Problem } from "./common";
-import { emptyYAMLNode, type MapWithNode, type SequenceWithNode, type WithNode, type YAMLNode } from "./yaml";
+import { type MapWithNode, type SequenceWithNode, type WithNode, type YAMLNode } from "./yaml";
 
 /**
  * Problems specific to `charmcraft.yaml`.
@@ -304,10 +304,4 @@ export interface CharmCharmcraft {
      * Root node.
      */
     node: YAMLNode;
-}
-
-export function emptyCharmcraft(): CharmCharmcraft {
-    return {
-        node: emptyYAMLNode(),
-    };
 }

--- a/src/model/config.yaml.ts
+++ b/src/model/config.yaml.ts
@@ -1,5 +1,5 @@
 import { type Problem } from "./common";
-import { emptyYAMLNode, type MapWithNode, type WithNode, type YAMLNode } from "./yaml";
+import { type MapWithNode, type WithNode, type YAMLNode } from "./yaml";
 
 /**
  * Problems specific to `config.yaml`.
@@ -31,10 +31,4 @@ export interface CharmConfig {
      * Root node.
      */
     node: YAMLNode;
-}
-
-export function emptyConfig(): CharmConfig {
-    return {
-        node: emptyYAMLNode(),
-    };
 }

--- a/src/model/metadata.yaml.ts
+++ b/src/model/metadata.yaml.ts
@@ -1,5 +1,5 @@
 import { type Problem } from "./common";
-import { emptyYAMLNode, type MapWithNode, type SequenceWithNode, type WithNode, type YAMLNode } from "./yaml";
+import { type MapWithNode, type SequenceWithNode, type WithNode, type YAMLNode } from "./yaml";
 
 /**
  * Problems specific to `metadata.yaml`.
@@ -117,10 +117,4 @@ export interface CharmMetadata {
      * Root node.
      */
     node: YAMLNode;
-}
-
-export function emptyMetadata(): CharmMetadata {
-    return {
-        node: emptyYAMLNode(),
-    };
 }

--- a/src/model/tox.ini.ts
+++ b/src/model/tox.ini.ts
@@ -26,8 +26,3 @@ export interface CharmToxConfigSection {
     parent: string;
 }
 
-export function emptyToxConfig(): CharmToxConfig {
-    return {
-        sections: {},
-    };
-}

--- a/src/model/yaml.ts
+++ b/src/model/yaml.ts
@@ -68,12 +68,3 @@ export function isMapWithNode<T>(v: any): v is MapWithNode<T> {
         && typeof v['entries'] === 'object'
         && !Array.isArray(v['entries']);
 }
-
-export function emptyYAMLNode(): YAMLNode {
-    return {
-        text: '',
-        raw: {},
-        problems: [],
-        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-    };
-}

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -368,8 +368,8 @@ export class CharmcraftTreeDataProvider implements TreeDataProvider<TreeItemMode
 
             function getNodeRange(option: CharmConfigOption) {
                 const node =
-                    option.definition === 'charmcraft.yaml' ? workspaceCharm.model.charmcraftYAML.config?.value?.options?.entries?.[option.name]?.node :
-                        option.definition === 'config.yaml' ? workspaceCharm.model.configYAML.parameters?.entries?.[option.name]?.node :
+                    option.definition === 'charmcraft.yaml' ? workspaceCharm.model.charmcraftYAML?.config?.value?.options?.entries?.[option.name]?.node :
+                        option.definition === 'config.yaml' ? workspaceCharm.model.configYAML?.parameters?.entries?.[option.name]?.node :
                             undefined;
                 return node?.range ?? node?.pairKeyRange ?? node?.pairValueRange;
             }
@@ -392,8 +392,8 @@ export class CharmcraftTreeDataProvider implements TreeDataProvider<TreeItemMode
 
             function getNodeRange(action: CharmAction) {
                 const node =
-                    action.definition === 'charmcraft.yaml' ? workspaceCharm.model.charmcraftYAML.actions?.entries?.[action.name]?.node :
-                        action.definition === 'actions.yaml' ? workspaceCharm.model.actionsYAML.actions?.entries?.[action.name]?.node :
+                    action.definition === 'charmcraft.yaml' ? workspaceCharm.model.charmcraftYAML?.actions?.entries?.[action.name]?.node :
+                        action.definition === 'actions.yaml' ? workspaceCharm.model.actionsYAML?.actions?.entries?.[action.name]?.node :
                             undefined;
                 return node?.range ?? node?.pairKeyRange ?? node?.pairValueRange;
             }
@@ -406,7 +406,7 @@ export class CharmcraftTreeDataProvider implements TreeDataProvider<TreeItemMode
         }
 
         if (element.kind === 'tox' && workspaceCharm.hasToxConfig) {
-            return filterAnsSortToxSections(Object.keys(workspaceCharm.model.toxINI.sections))
+            return filterAnsSortToxSections(Object.keys(workspaceCharm.model.toxINI?.sections ?? {}))
                 .map(section => {
                     const components = section.split(':');
                     const group = components.slice(0, -1).join(':');
@@ -436,11 +436,11 @@ export class CharmcraftTreeDataProvider implements TreeDataProvider<TreeItemMode
 
 function getWorkspaceCharmLabel(workspaceCharm: WorkspaceCharm): string {
     const name =
-        workspaceCharm.model.charmcraftYAML.name?.value ??
-        workspaceCharm.model.metadataYAML.name?.value;
+        workspaceCharm.model.charmcraftYAML?.name?.value ??
+        workspaceCharm.model.metadataYAML?.name?.value;
     const title =
-        workspaceCharm.model.charmcraftYAML.title?.value ??
-        workspaceCharm.model.metadataYAML.displayName?.value;
+        workspaceCharm.model.charmcraftYAML?.title?.value ??
+        workspaceCharm.model.metadataYAML?.displayName?.value;
     return name || title
         ? `${name ?? '?'} (${title ?? '?'})`
         : basename(workspaceCharm.home.path);


### PR DESCRIPTION
This PR adds a few basic cross-file diagnostics, for when options/actions are defined in both `charmcraft.yaml` and `config.yaml`/`actions.yaml`, based on the discussion in #33.

Fixes #33